### PR TITLE
V.099

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 Unofficial Mutant Year Zero system for FoundryVTT
 
+## v0.99
+-   Fixed BUG with translation string when pushing attribute
+-   Added translated name to the skill roll in a chat message.
+-   Allows NPC to roll weapon without having fight/shoot skill
+
 ## v0.98
 -   Skills on character sheets now use translation key to display their name in selected language.
 -   Language JSONs are sorted alphabeticaly for easier update.

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -212,7 +212,11 @@ export class MYZActorSheet extends ActorSheet {
             }
             if (!skill) {
                 ui.notifications.warn(game.i18n.localize("MYZ.NO_COMBAT_SKILL"));
-                return;
+                skill = {
+                    data:{
+                        value:0
+                    }
+                };
             }
             
             RollDialog.prepareRollDialog({
@@ -397,16 +401,21 @@ export class MYZActorSheet extends ActorSheet {
     _onRollSkill(event) {
         event.preventDefault();
         const element = event.currentTarget;
-        //const dataset = element.dataset;
         const itemId = $(element).data("item-id");
         if (itemId) {
             //FIND OWNED SKILL ITEM AND CREARE ROLL DIALOG
             const skill = this.actor.items.find((element) => element._id == itemId);
-            //let baseDice = this.actor.data.attributes[skill.data.data.attribute].value;
             let baseDice = this.actor.data.data.attributes[skill.data.data.attribute].value;
+            // SEE IF WE CAN USE SKILL KEY TO TRANSLATE THE NAME
+            let skillName = "";
+            if(skill.data.data.skillKey==""){
+                skillName = skill.data.name;
+            }else{
+                skillName = game.i18n.localize(`MYZ.SKILL_${skill.data.data.skillKey}`);
+            }
 
             RollDialog.prepareRollDialog({
-                rollName: skill.data.name,
+                rollName: skillName,
                 diceRoller: this.diceRoller,
                 baseDefault: baseDice,
                 skillDefault: skill.data.data.value,

--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
     "name": "mutant-year-zero",
     "title": "Mutant Year Zero",
     "description": "The Mutant Year Zero system for FoundryVTT!",
-    "version": "0.98",
+    "version": "0.99",
     "minimumCoreVersion": "0.7.5",
     "compatibleCoreVersion": "0.7.9",
     "templateVersion": 1,
@@ -61,7 +61,7 @@
     "gridDistance": 1,
     "gridUnits": "m",
     "url": "https://github.com/superseva/mutant-year-zero",
-    "manifest": "https://github.com/superseva/mutant-year-zero/releases/download/v0.98/system.json",
-    "download": "https://github.com/superseva/mutant-year-zero/releases/download/v0.98/mutant-year-zero.zip",
+    "manifest": "https://github.com/superseva/mutant-year-zero/releases/download/v0.99/system.json",
+    "download": "https://github.com/superseva/mutant-year-zero/releases/download/v0.99/mutant-year-zero.zip",
     "license": "LICENSE.txt"
 }

--- a/templates/chat/roll.html
+++ b/templates/chat/roll.html
@@ -1,7 +1,7 @@
 <div class="myz chat-item">
     <div class="border">
         {{#if isPushed}}
-        <h3>{{name}} - {{localize "MYZ.PUSHED"}}</h3>
+        <h3>{{localize name}} - {{localize "MYZ.PUSHED"}}</h3>
         {{else}}
         <h3>{{localize name}}</h3>
         {{/if}}


### PR DESCRIPTION
-   Fixed BUG with translation string when pushing attribute
-   Added translated name to the skill roll in a chat message.
-   Allows NPC to roll weapon without having fight/shoot skill