### PR TITLE
:sparkles: Roll Push Effects: Traumas & Gear Damage

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -232,5 +232,9 @@
 	"MYZ.WEIGHT_TINY": "Tiny",
 	"MYZ.WEIGHTLESS": "Weightless",
 	"MYZ.WORK_POINTS": "Work Points",
-	"MYZ.XP": "XP"
+	"MYZ.XP": "XP",
+	"SETTINGS.ApplyPushTraumaN": "Apply Push Trauma",
+	"SETTINGS.ApplyPushTraumaH": "Whether to apply trauma from banes on pushed rolls.",
+	"SETTINGS.ApplyPushGearDamageN": "Apply Push Gear Damage",
+	"SETTINGS.ApplyPushGearDamageH": "Whether to apply gear damage from banes on pushed rolls."
 }

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -125,7 +125,7 @@ export class MYZActorSheet extends ActorSheet {
         });
 
         html.find(".button-push").click((ev) => {
-            this.diceRoller.push();
+            this.diceRoller.push({ actor: this.actor });
         });
 
         /* -------------------------------------------- */
@@ -222,6 +222,8 @@ export class MYZActorSheet extends ActorSheet {
 
             RollDialog.prepareRollDialog({
                 rollName: testName,
+                attributeName: skill.data.data.attribute,
+                itemId,
                 diceRoller: this.diceRoller,
                 baseDefault: attribute.value,
                 skillDefault: skill.data.data.value,
@@ -389,6 +391,7 @@ export class MYZActorSheet extends ActorSheet {
         let rollName = `MYZ.ATTRIBUTE_${attName.toUpperCase()}_${this.actor.data.data.creatureType.toUpperCase()}`;
         RollDialog.prepareRollDialog({
             rollName: rollName,
+            attributeName: attName,
             diceRoller: this.diceRoller,
             baseDefault: attVal,
             skillDefault: 0,
@@ -409,7 +412,8 @@ export class MYZActorSheet extends ActorSheet {
         if (itemId) {
             //FIND OWNED SKILL ITEM AND CREARE ROLL DIALOG
             const skill = this.actor.items.find((element) => element.id == itemId);
-            let baseDice = this.actor.data.data.attributes[skill.data.data.attribute].value;
+            const attName = skill.data.data.attribute;
+            let baseDice = this.actor.data.data.attributes[attName].value;
             // SEE IF WE CAN USE SKILL KEY TO TRANSLATE THE NAME
             let skillName = "";
             if (skill.data.data.skillKey == "") {
@@ -420,6 +424,7 @@ export class MYZActorSheet extends ActorSheet {
 
             RollDialog.prepareRollDialog({
                 rollName: skillName,
+                attributeName: attName,
                 diceRoller: this.diceRoller,
                 baseDefault: baseDice,
                 skillDefault: skill.data.data.value,

--- a/module/app/roll-dialog.js
+++ b/module/app/roll-dialog.js
@@ -5,6 +5,8 @@ export class RollDialog {
      * Display roll dialog and execute the roll.
      *
      * @param  {string}        rollName
+     * @param  {string}       [attributeName]  The key of the used attribute (for push data)
+     * @param  {string}       [itemId]         The ID of the used item (for push data)
      * @param  {object|number} baseDefault     {name: "somename", value: 5} | 5
      * @param  {object|number} skillDefault    {name: "somename", value: 5} | 5
      * @param  {number}        gearDefault
@@ -17,6 +19,8 @@ export class RollDialog {
     //static prepareRollDialog(rollName, baseDefault, skillDefault, gearDefault, artifactDefault, modifierDefault, damage, diceRoller, onAfterRoll) {
     static async prepareRollDialog({
         rollName = "",
+        attributeName = null,
+        itemId = null,
         baseDefault = 0,
         skillDefault = 0,
         gearDefault = 0,
@@ -56,6 +60,7 @@ export class RollDialog {
                             let gear = html.find("#gear")[0].value;
                             let artifact = this.parseArtifact(html.find("#artifact")[0].value);
                             let modifier = html.find("#modifier")[0].value;
+                            diceRoller.preparePushData(attributeName, itemId);
                             diceRoller.roll({
                                 rollName: rollName,
                                 base: parseInt(base, 10),

--- a/module/component/dice-roller.js
+++ b/module/component/dice-roller.js
@@ -10,6 +10,8 @@ export class DiceRoller {
     diceWithNoResult = [];
     attribute = null;
     itemId = null;
+    traumaCount = 0;
+    gearDamageCount = 0;
 
     /**
      * @param  {string} rollName   Display name for the roll
@@ -77,7 +79,7 @@ export class DiceRoller {
         ) {
             const updateData = {};
             const actorData = actor.data.data;
-            const baneCount = this.countFailures();
+            const baneCount = this.countFailures() - this.traumaCount;
             if (baneCount > 0) {
                 // Decreases the attribute.
                 const attributes = actorData.attributes || {};
@@ -98,6 +100,7 @@ export class DiceRoller {
                         updateData[`data.resource_points.value`] = newVal;
                     }
                 }
+                this.traumaCount += baneCount;
             }
             if (!foundry.utils.isObjectEmpty(updateData)) {
                 actor.update(updateData);
@@ -107,7 +110,7 @@ export class DiceRoller {
         // Applies pushed roll effect to the gear.
         if (actor && this.itemId && game.settings.get("mutant-year-zero", "applyPushGearDamage")) {
             const item = actor.items.get(this.itemId);
-            const baneCount = this.countGearFailures();
+            const baneCount = this.countGearFailures() - this.gearDamageCount;
             if (item && baneCount > 0) {
                 const bonus = item.data.data.bonus;
                 if (bonus) {
@@ -116,6 +119,7 @@ export class DiceRoller {
                     if (newVal !== value) {
                         item.update({ 'data.bonus.value': newVal });
                     }
+                    this.gearDamageCount += baneCount;
                 }
             }
         }
@@ -271,6 +275,8 @@ export class DiceRoller {
     preparePushData(attribute = null, itemId = null) {
         this.attribute = attribute;
         this.itemId = itemId;
+        this.traumaCount = 0;
+        this.gearDamageCount = 0;
         // console.warn("DiceRoller | preparePushData:", attribute, itemId);
         return this;
     }

--- a/module/settings.js
+++ b/module/settings.js
@@ -9,4 +9,22 @@ export const registerSystemSettings = function () {
         type: Number,
         default: 0,
     });
+
+    game.settings.register("mutant-year-zero", "applyPushTrauma", {
+        name: "SETTINGS.ApplyPushTraumaN",
+        hint: "SETTINGS.ApplyPushTraumaH",
+        config: true,
+        scope: "world",
+        type: Boolean,
+        default: true,
+    });
+
+    game.settings.register("mutant-year-zero", "applyPushGearDamage", {
+        name: "SETTINGS.ApplyPushGearDamageN",
+        hint: "SETTINGS.ApplyPushGearDamageH",
+        config: true,
+        scope: "world",
+        type: Boolean,
+        default: true,
+    });
 };

--- a/template.json
+++ b/template.json
@@ -113,7 +113,7 @@
 			"templates": ["base", "stats", "status"],
 			"description": "",
 			"coreSkills": ["ENDURE", "FORCE", "FIGHT", "SNEAK", "MOVE", "SHOOT", "SCOUT", "COMPREHEND", "KNOWTHEZONE", "SENSEEMOTION", "DOMINATE", "HEAL"],
-			"resourcepoints": {
+			"resource_points": {
 				"label": "MYZ.FERAL_POINTS",
 				"value": 0,
 				"max": 10


### PR DESCRIPTION
This PR adds a new feature for automatic push effects: 
- Attribute traumas for pushed attribute & skill rolls
- Gear damage if an item with a bonus was used
- Increases resources points by one for each bane rolled on pushed rolls.
- Includes also additional system settings to make this rule optional.
- Includes also a fix for a typo in the `template.json` (animal's resource_points).<br/>Might require a migration to fix older animals.

The achieve this, I have added two new properties to the `DiceRoller`:
- `diceRoller.attribute`: stores the attribute used by the last roll, if any (armor and rad rolls have no attribute).
- `diceRoller.itemId`: stores the ID of the item used by the last roll, if any.

