### PR TITLE
allow sorting weapons, armor and gear in the actor sheet

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -19,7 +19,7 @@ export class MYZActorSheet extends ActorSheet {
             actor: actorData,
             source: source.system,
             system: actorData.system,
-            items: actorData.items,
+            items: actorData.items.sort((a, b) => (a.sort || 0) - (b.sort || 0)),
             effects: prepareActiveEffectCategories(this.actor.effects),
             owner: this.actor.isOwner,
             limited: this.actor.limited,

--- a/templates/actor/partials/armors.html
+++ b/templates/actor/partials/armors.html
@@ -9,9 +9,9 @@
         <a class="item-create" data-type="armor">{{localize "MYZ.Add"}}</a>
     </div>
 </div>
-<ol class="box-list {{system.creatureType}}">
+<ol class="item-list box-list {{system.creatureType}}">
     {{#each armor as |armor key|}}
-    <li class="box-item physical flex row align-center space-between editable-armor" data-physical="1" data-item-id="{{armor._id}}">
+    <li class="item box-item physical flex row align-center space-between editable-armor" data-physical="1" data-item-id="{{armor._id}}">
         <span class="item-name flex row align-center {{#if (isBroken armor)}}broken{{/if}}" data-item-id="{{armor._id}}">
             <img class="item-image" src="{{armor.img}}" />
             <a class="rollable armor-item-roll">{{armor.name}}</a>

--- a/templates/actor/partials/gear.html
+++ b/templates/actor/partials/gear.html
@@ -4,9 +4,9 @@
         <a class="item-create" data-type="gear">{{localize "MYZ.Add"}}</a>
     </span>
 </div>
-<ol class="box-list gear {{system.creatureType}}">
+<ol class="item-list box-list gear {{system.creatureType}}">
     {{#each gear as |gear key|}}
-    <li class="box-item gear flex row align-center space-between editable-item" data-physical="1" data-item-id="{{gear._id}}">
+    <li class="item box-item gear flex row align-center space-between editable-item" data-physical="1" data-item-id="{{gear._id}}">
         <span class="item-name flex row align-center">
             <img class="item-image" src="{{gear.img}}" />
             <label>{{gear.name}} &nbsp;</label>

--- a/templates/actor/partials/weapons.html
+++ b/templates/actor/partials/weapons.html
@@ -9,9 +9,9 @@
         <a class="item-create" data-type="weapon">{{localize "MYZ.Add"}}</a>
     </div>
 </div>
-<ol class="box-list {{system.creatureType}}">
+<ol class="item-list box-list {{system.creatureType}}">
     {{#each weapons as |weapon key|}}
-    <li class="box-item physical flex row align-center space-between editable-item weapon" data-physical="1" data-item-id="{{weapon._id}}">
+    <li class="item box-item physical flex row align-center space-between editable-item weapon" data-physical="1" data-item-id="{{weapon._id}}">
         <span class="item-name flex row align-center roll-weapon rollable {{#if (isBroken weapon)}}broken{{/if}}" data-item-id="{{weapon._id}}">
             <img class="item-image" src="{{weapon.img}}" />
             <a>{{weapon.name}}</a>


### PR DESCRIPTION
Hello,

I've seen your answer to the previous pull request, nevertheless..

I suggest 4 small modifications to allow sorting some items (weapons, armor and gear specifically) inside the actor sheet:
- add of "item-list" and "item" classes to the partial templates of weapons, armor and gear;
- replacement of "items: actorData.items," by "items: actorData.items.sort((a, b) => (a.sort || 0) - (b.sort || 0))," in the getData function of the actorsheet.js so that the items can effectively be sorted.

Incidentally, it also allows the use of the 'Item Piles" module with mutant year zero, which is great.

Have a good holiday !

